### PR TITLE
Allow user to exclude paths in the repo, and group lines changed by file type

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ Run `git fame` to generate output as above.
 
 #### Options
 
+- `git fame --bytype` Should a breakout of line counts by file type be output? Default is 'false'
+- `git fame --exclude=paths/to/files,paths/to/other/files` Comma separated paths to exclude from the counts. Default is none.
 - `git fame --order=loc` Order table by `loc`. Available options are: `loc`, `commits` and `files`. Default is `loc`.
-- `git fame --repository=/path/to/repo` Git repository to be used. Default is the current folder.
 - `git fame --progressbar=1` Should a progressbar be visible during the calculation? Default is `1`.
+- `git fame --repository=/path/to/repo` Git repository to be used. Default is the current folder.
 
 ### Class
 
@@ -57,12 +59,16 @@ Want to work with the data before printing it?
 - **repository** (String) Path to repository.
 - **sort** (String) What should #authors be sorted by? Available options are: `loc`, `commits` and `files`. Default is `loc`.
 - **progressbar** (Boolean) Should a progressbar be shown during the calculation? Default is `false`.
+- **bytype** (Boolean) Should a breakout of line counts by file type be output? Default is 'false'
+- **exclude** (String) Comma separated paths to exclude from the counts. Default is none.
 
 ``` ruby
 repository = GitFame::Base.new({
-  sort: "loc", 
+  sort: "loc",
   repository: "/tmp/repo",
-  progressbar: false
+  progressbar: false,
+  bytype: false,
+  exclude: "vendor, public/assets"
 })
 ```
 
@@ -92,6 +98,11 @@ repository = GitFame::Base.new({
   - `author.raw_loc` (Fixnum) Number of lines.
   - `author.raw_commits` (Fixnum) Number of commits.
   - `author.raw_files` (Fixnum) Number of files changed.
+  - `author.file_type_counts` (Array) File types (k) and loc (v)
+
+#### A note about authors found
+
+The list of authors may include what you perceive to be duplicate people. If a git user's configured name or email address change over time, the person will appear multiple times in this list (and your repo's git history).  Git allows you to configure this using the .mailmap feature. See ````git shortlog --help```` for more information.
 
 ## Contributing
 

--- a/bin/git-fame
+++ b/bin/git-fame
@@ -9,6 +9,8 @@ opts = Trollop::options do
   opt :repository, "What git repository should be used?", default: "."
   opt :sort, "What should the printed table be sorted by? #{sort.join(", ")}", default: "loc", type: String
   opt :progressbar, "Show progressbar during calculation", default: 1, type: Integer
+  opt :bytype, "Group line counts by file extension (i.e. .rb, .erb, .yml)", default: false
+  opt :exclude, "Paths to exclude (comma separated)", default: "", type: String
 end
 
 Trollop::die :repository, "is not a git repository" unless GitFame::Base.git_repository?(opts[:repository])
@@ -16,5 +18,7 @@ Trollop::die :sort, "must be one of the following; #{sort.join(", ")}" unless so
 GitFame::Base.new({
   repository: opts[:repository],
   progressbar: opts[:progressbar] == 1,
-  sort: opts[:sort]
+  sort: opts[:sort],
+  bytype: opts[:bytype],
+  exclude: opts[:exclude]
 }).pretty_puts

--- a/lib/git_fame/author.rb
+++ b/lib/git_fame/author.rb
@@ -1,7 +1,7 @@
 module GitFame
   class Author
     include GitFame::Helper
-    attr_accessor :name, :raw_files, :raw_commits, :raw_loc, :files_list
+    attr_accessor :name, :raw_files, :raw_commits, :raw_loc, :files_list, :file_type_counts
     #
     # @args Hash
     #
@@ -9,6 +9,7 @@ module GitFame
       @raw_loc = 0
       @raw_commits = 0
       @raw_files = 0
+      @file_type_counts = Hash.new(0)
       args.keys.each { |name| instance_variable_set "@" + name.to_s, args[name] }
     end
 
@@ -26,5 +27,13 @@ module GitFame
         number_with_delimiter(send("raw_#{method}"))
       end
     end
+
+    #
+    # Intended to catch file type counts
+    #
+    def method_missing(m, *args, &block)
+      file_type_counts[m.to_s]
+    end
+
   end
 end

--- a/spec/git_fame_spec.rb
+++ b/spec/git_fame_spec.rb
@@ -68,6 +68,22 @@ describe GitFame::Base do
     end
   end
 
+  describe "#command_line_arguments" do
+    let(:subject) { GitFame::Base.new({repository: @repository, exclude: "lib", bytype: true }) }
+    it "should exclude the lib folder" do
+      subject.file_list.include?("lib/gash.rb").should be_false
+    end
+
+    let(:author) { subject.authors.first }
+    it "should break out counts by file type" do
+      author.file_type_counts["rdoc"].should eq(23)
+    end
+
+    it "should output zero for file types the author hasn't touched" do
+      author.file_type_counts["derp"].should eq(0)
+    end
+  end
+
   describe "#pretty_print" do
     it "should print" do
       lambda {


### PR DESCRIPTION
Added two new arguments:

1) **exclude** Allow the user to exclude certain paths in the repo. In the case of a Rails 4 project, excluding vendors or config/locales might be desirable to get a more realistic idea of authors' contributions

2) **bytype** Allow the output of line counts by file type (ruby, erb, yml, js). In the case of git-fame-rb, 7rans wrote the rdocs and Linus Oleander wrote all the ruby. This is especially helpful on larger teams/projects. [ unknown files are files without an extension. If you can think of a better way to represent these, have at it! ]

I also wrote a few tests (though rspec isn't my strongest suit) and modified the readme. I believe my addition about . mailmap is warranted since exactly where those author names come from is a mystery (unless one digs into the gem, and understands git shortlog).

Example of line count by file type output:
![screen shot 2013-11-13 at 10 55 53 pm](https://f.cloud.github.com/assets/515046/1538304/b1c3e09c-4ce0-11e3-9023-f994e5384590.png)
