### PR TITLE
BUGFIX: File extension names could conflict with methods

### DIFF
--- a/lib/git_fame/base.rb
+++ b/lib/git_fame/base.rb
@@ -131,7 +131,7 @@ module GitFame
         @files.each do |file|
           progressbar.inc
           if @bytype
-            file_extension = File.extname(file).sub(/\A\./,"")
+            file_extension = File.extname(file)
             file_extension = "unknown" if file_extension.empty?
           end
           if type = Mimer.identify(File.join(@repository, file)) and not type.mime_type.match(/binary/)


### PR DESCRIPTION
This patch simply changes the file extensions, preserving the "." (period) at
the beginning of the extension.

The Hirb gem, used to output the table in the gem's output, essentially calls
object.send(field_name) to output each row's (Author's) column. In the case of
a file extension of "test", this was sending author.test. Test is a private
method on the Ruby Object class, thus Hirb was inadvertently calling "test"
instead of outputting what we expect.

Now, the column names are ".test", ".js", etc., which is still readable.