### PR TITLE
Add --include option

### DIFF
--- a/bin/git-fame
+++ b/bin/git-fame
@@ -11,6 +11,7 @@ opts = Trollop::options do
   opt :progressbar, "Show progressbar during calculation", default: 1, type: Integer
   opt :whitespace, "Ignore whitespace changes", default: false
   opt :bytype, "Group line counts by file extension (i.e. .rb, .erb, .yml)", default: false
+  opt :include, "Paths to include in git ls-files", default: "", type: String
   opt :exclude, "Paths to exclude (comma separated)", default: "", type: String
 end
 
@@ -22,5 +23,6 @@ GitFame::Base.new({
   sort: opts[:sort],
   whitespace: opts[:whitespace],
   bytype: opts[:bytype],
+  include: opts[:include],
   exclude: opts[:exclude]
 }).pretty_puts

--- a/lib/git_fame/base.rb
+++ b/lib/git_fame/base.rb
@@ -14,6 +14,7 @@ module GitFame
       @whitespace   = false
       @bytype       = false
       @exclude      = ""
+      @include      = ""
       @authors      = {}
       @file_authors = Hash.new { |h,k| h[k] = {} }
       args.keys.each do |name| 
@@ -123,7 +124,7 @@ module GitFame
     #
     def populate
       @_pop ||= lambda {
-        @files = execute("git ls-files").split("\n")
+        @files = execute("git ls-files #{@include}").split("\n")
         @file_extensions = []
         remove_excluded_files
         progressbar = SilentProgressbar.new("Blame", @files.count, @progressbar)


### PR DESCRIPTION
Repositories that include many non-source files can be more easily analyzed by passing arguments to `git ls-files`. This allows a user to whitelist specific filetypes or directories (eg. --include src/*.py), instead of individually blacklisting all non-relevant files with --exclude (eg. --exclude "res/,lib/,third-party-lib-1/,third-party-lib/2,...").

Note: git-fame will process the intersection of the sets of files allowed by --include and --exclude.