### PR TITLE
Add features: #include, #since, #until

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.idea
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Want to work with the data before printing it?
 - **whitespace** (Boolean) Ignore whitespace changes when blaming files. Default is `false`.
 - **bytype** (Boolean) Should a breakout of line counts by file type be output? Default is 'false'
 - **exclude** (String) Comma separated paths to exclude from the counts. Default is none.
+- **include** (String) Comma separated paths to exclude from the counts. Default is `*`.
+- **since** (String) Comma separated paths to exclude from the counts. Default is `1970-01-01`.
+- **until** (String) Comma separated paths to exclude from the counts. Default is `now`.
 
 ``` ruby
 repository = GitFame::Base.new({
@@ -92,11 +95,11 @@ repository = GitFame::Base.new({
 
 `author = repository.authors.first`
 
-- Formated
+- Formatted
   - `author.loc` (String) Number of lines.
   - `author.commits` (String) Number of commits.
   - `author.files` (String) Number of files changed.
-- Non formated
+- Non formatted
   - `author.distribution` (String) Distribution (in %) between users (loc/commits/files)
   - `author.raw_loc` (Fixnum) Number of lines.
   - `author.raw_commits` (Fixnum) Number of commits.

--- a/README.md
+++ b/README.md
@@ -46,10 +46,13 @@ Run `git fame` to generate output as above.
 
 - `git fame --bytype` Should a breakout of line counts by file type be output? Default is 'false'
 - `git fame --exclude=paths/to/files,paths/to/other/files` Comma separated paths to exclude from the counts. Default is none.
+- `git fame --include=paths/to/files,paths/to/other/files` Comma separated paths to include to the counts. Default is none.
 - `git fame --order=loc` Order table by `loc`. Available options are: `loc`, `commits` and `files`. Default is `loc`.
 - `git fame --progressbar=1` Should a progressbar be visible during the calculation? Default is `1`.
 - `git fame --whitespace` Ignore whitespace changes when blaming files. Default is `false`.
 - `git fame --repository=/path/to/repo` Git repository to be used. Default is the current folder.
+- `git fame --since=git-time` Time to count from. Default is start of project or `1970-01-01`.
+- `git fame --until=git-time` Time to count until. Default is `now`.
 
 ### Class
 
@@ -63,9 +66,9 @@ Want to work with the data before printing it?
 - **whitespace** (Boolean) Ignore whitespace changes when blaming files. Default is `false`.
 - **bytype** (Boolean) Should a breakout of line counts by file type be output? Default is 'false'
 - **exclude** (String) Comma separated paths to exclude from the counts. Default is none.
-- **include** (String) Comma separated paths to exclude from the counts. Default is `*`.
-- **since** (String) Comma separated paths to exclude from the counts. Default is `1970-01-01`.
-- **until** (String) Comma separated paths to exclude from the counts. Default is `now`.
+- **include** (String) Comma separated paths to include to the counts. All not mentioned are excluded. Default is `*`.
+- **since** (String) Time to count from. Default is `1970-01-01`.
+- **until** (String) Time to count until. Default is `now`.
 
 ``` ruby
 repository = GitFame::Base.new({

--- a/bin/git-fame
+++ b/bin/git-fame
@@ -11,7 +11,10 @@ opts = Trollop::options do
   opt :progressbar, "Show progressbar during calculation", default: 1, type: Integer
   opt :whitespace, "Ignore whitespace changes", default: false
   opt :bytype, "Group line counts by file extension (i.e. .rb, .erb, .yml)", default: false
+  opt :include, "Paths to include (comma separated). Default all files", default: "", type: String
   opt :exclude, "Paths to exclude (comma separated)", default: "", type: String
+  opt :since, "Since time", defaut: "", type: String
+  opt :until, "Until time", defaut: "now", type: String
 end
 
 Trollop::die :repository, "is not a git repository" unless GitFame::Base.git_repository?(opts[:repository])
@@ -22,5 +25,8 @@ GitFame::Base.new({
   sort: opts[:sort],
   whitespace: opts[:whitespace],
   bytype: opts[:bytype],
-  exclude: opts[:exclude]
+  exclude: opts[:exclude],
+  include: opts[:include],
+  since: opts[:since],
+  until: opts[:until]
 }).pretty_puts

--- a/lib/git_fame/author.rb
+++ b/lib/git_fame/author.rb
@@ -24,7 +24,10 @@ module GitFame
     #
     def distribution
       "%.1f / %.1f / %.1f" % [:loc, :commits, :files].
-        map{ |w| (send("raw_#{w}") / @parent.send(w).to_f) * 100 }
+        map{ |w|
+          k = @parent.send(w).to_f
+          k < 1E-6 ? 0 : (send("raw_#{w}") / k) * 100
+         }
     end
 
     [:commits, :files, :loc, :added, :deleted, :total].each do |method|

--- a/lib/git_fame/author.rb
+++ b/lib/git_fame/author.rb
@@ -1,12 +1,15 @@
 module GitFame
   class Author
     include GitFame::Helper
-    attr_accessor :name, :raw_files, :raw_commits, :raw_loc, :files_list, :file_type_counts
+    attr_accessor :name, :raw_files, :raw_commits, :raw_loc, :raw_added, :raw_deleted, :raw_total, :files_list, :file_type_counts
     #
     # @args Hash
     #
     def initialize(args = {})
       @raw_loc          = 0
+      @raw_added        = 0
+      @raw_deleted      = 0
+      @raw_total        = 0
       @raw_commits      = 0
       @raw_files        = 0
       @file_type_counts = Hash.new(0)
@@ -24,7 +27,7 @@ module GitFame
         map{ |w| (send("raw_#{w}") / @parent.send(w).to_f) * 100 }
     end
 
-    [:commits, :files, :loc].each do |method|
+    [:commits, :files, :loc, :added, :deleted, :total].each do |method|
       define_method(method) do
         number_with_delimiter(send("raw_#{method}"))
       end

--- a/lib/git_fame/base.rb
+++ b/lib/git_fame/base.rb
@@ -150,7 +150,7 @@ module GitFame
             begin
               blame_cmd = "git blame '#{file}' #{blame_opts} --line-porcelain "
               if @since
-                blame_cmd += " --since=#{@since}"
+                blame_cmd += " --since=#{@since}" # blame doesn't have until flag
               end
               execute(blame_cmd).scan(/^author (.+)$/).each do |author|
                 fetch(author.first).raw_loc += 1
@@ -165,7 +165,7 @@ module GitFame
           progressbar_authors = SilentProgressbar.new("Authors", @authors.count, @progressbar)
           @authors.each do |name, author|
             progressbar_authors.inc
-            lines_stat_cmd = "git log --author='#{name}' --after=#{@since || '1970'} --before=#{@until || 'now'} --pretty=tformat: --numstat | " + %q[gawk '{ add += $1 ; subs += $2 ; loc += $1 - $2 } END { printf "%s %s %s\n",add,subs,loc }']
+            lines_stat_cmd = "git log --author='#{name}' --after=#{@since || '1970'} --before=#{@until || 'now'} --pretty=tformat: --numstat #{@include.join(' ')} | " + %q[gawk '{ add += $1 ; subs += $2 ; loc += $1 - $2 } END { printf "%s %s %s\n",add,subs,loc }']
             added, deleted, total = execute(lines_stat_cmd).scan(/\d+/).map{|s| s.to_i}
             author.raw_added = added || 0
             author.raw_deleted = deleted || 0
@@ -225,7 +225,7 @@ module GitFame
     def remove_excluded_files
       return if @exclude.empty?
       @files = @files.map do |path|
-        next if  path =~ /\A(#{@exclude.join("|")})/
+        next if  path =~ /\A(#{@exclude.join('|')})/
         path
       end.compact
     end

--- a/lib/git_fame/base.rb
+++ b/lib/git_fame/base.rb
@@ -73,6 +73,20 @@ module GitFame
     end
 
     #
+    # @return Fixnum Total number of lines added
+    #
+    def added
+      populate.authors.inject(0){ |result, author| author.raw_added + result }
+    end
+
+    #
+    # @return Fixnum Total number of lines added
+    #
+    def deleted
+      populate.authors.inject(0){ |result, author| author.raw_deleted + result }
+    end
+
+    #
     # @return Array<Author> A list of authors
     #
     def authors

--- a/lib/git_fame/base.rb
+++ b/lib/git_fame/base.rb
@@ -9,16 +9,20 @@ module GitFame
     # @args[:exclude] String Comma-separated list of paths in the repo which should be excluded
     #
     def initialize(args)
-      @sort         = "loc"
+      @sort         = 'loc'
       @progressbar  = false
       @whitespace   = false
       @bytype       = false
-      @exclude      = ""
+      @exclude      = ''
+      @include      = ''
+      @since        = '1970-01-01'
+      @until        = 'now'
       @authors      = {}
       @file_authors = Hash.new { |h,k| h[k] = {} }
       args.keys.each do |name| 
-        instance_variable_set "@" + name.to_s, args[name]
+        instance_variable_set '@' + name.to_s, args[name]
       end
+      convert_include_paths_to_array
       convert_exclude_paths_to_array
     end
 
@@ -33,6 +37,9 @@ module GitFame
       puts "Total number of commits: #{number_with_delimiter(commits)}\n"
 
       fields = [:name, :loc, :commits, :files, :distribution]
+      if @since or @until
+        fields << :added << :deleted << :total
+      end
       fields << populate.instance_variable_get("@file_extensions").uniq.sort if @bytype
       table(authors, fields: fields.flatten)
     end
@@ -79,7 +86,7 @@ module GitFame
       end : authors
     end
 
-    #
+    #f
     # @return Boolean Is the given @dir a git repository?
     # @dir Path (relative or absolute) to git repository
     #
@@ -123,13 +130,17 @@ module GitFame
     #
     def populate
       @_pop ||= lambda {
-        @files = execute("git ls-files").split("\n")
+        if @include.empty?
+          @files = execute("git ls-files").split("\n")
+        else
+          @files = execute("git ls-files " + @include.join(" ")).split("\n")
+        end
         @file_extensions = []
         remove_excluded_files
-        progressbar = SilentProgressbar.new("Blame", @files.count, @progressbar)
+        progressbar_blame = SilentProgressbar.new("Blame", @files.count, @progressbar)
         blame_opts = @whitespace ? "-w" : ""
         @files.each do |file|
-          progressbar.inc
+          progressbar_blame.inc
           if @bytype
             file_extension = File.extname(file).sub(/\A\./,"")
             file_extension = "unknown" if file_extension.empty?
@@ -137,7 +148,11 @@ module GitFame
           if type = Mimer.identify(File.join(@repository, file)) and not type.mime_type.match(/binary/)
             @file_extensions << file_extension # only count extensions that aren't binary!
             begin
-              execute("git blame '#{file}' #{blame_opts} --line-porcelain").scan(/^author (.+)$/).each do |author|
+              blame_cmd = "git blame '#{file}' #{blame_opts} --line-porcelain "
+              if @since
+                blame_cmd += " --since=#{@since}"
+              end
+              execute(blame_cmd).scan(/^author (.+)$/).each do |author|
                 fetch(author.first).raw_loc += 1
                 @file_authors[author.first][file] ||= 1
                 fetch(author.first).file_type_counts[file_extension] += 1 if @bytype
@@ -146,7 +161,27 @@ module GitFame
           end
         end
 
-        execute("git shortlog -se").split("\n").map do |l|
+        if @since or @until
+          progressbar_authors = SilentProgressbar.new("Authors", @authors.count, @progressbar)
+          @authors.each do |name, author|
+            progressbar_authors.inc
+            lines_stat_cmd = "git log --author='#{name}' --after=#{@since || '1970'} --before=#{@until || 'now'} --pretty=tformat: --numstat | " + %q[gawk '{ add += $1 ; subs += $2 ; loc += $1 - $2 } END { printf "%s %s %s\n",add,subs,loc }']
+            added, deleted, total = execute(lines_stat_cmd).scan(/\d+/).map{|s| s.to_i}
+            author.raw_added = added || 0
+            author.raw_deleted = deleted || 0
+            author.raw_total = total || 0
+          end
+          progressbar_authors.finish
+        end
+
+        shortlog_cmd = "git shortlog -se "
+        if @since
+          shortlog_cmd += ' --since=' + @since
+        end
+        if @until
+          shortlog_cmd += ' --until=' + @until
+        end
+        execute(shortlog_cmd).split("\n").map do |l|
           _, commits, u = l.match(%r{^\s*(\d+)\s+(.+?)\s+<.+?>}).to_a
           user = fetch(u)
           # Has this user been updated before?
@@ -167,7 +202,7 @@ module GitFame
           end
         end
 
-        progressbar.finish
+        progressbar_blame.finish
 
       }.call
       return self
@@ -178,6 +213,10 @@ module GitFame
     #
     def convert_exclude_paths_to_array
       @exclude = @exclude.split(",").map{|path| path.strip.sub(/\A\//, "") }
+    end
+
+    def convert_include_paths_to_array
+      @include = @include.split(",").map{|path| path.strip.sub(/\A\//, "") }
     end
 
     #

--- a/lib/git_fame/helper.rb
+++ b/lib/git_fame/helper.rb
@@ -1,8 +1,8 @@
 module GitFame
   module Helper
     #
-    # @value Fixnum Value to be formated
-    # @return String Formated according ActionView::Helpers::NumberHelper.number_with_delimiter
+    # @value Fixnum Value to be formatted
+    # @return String Formatted according ActionView::Helpers::NumberHelper.number_with_delimiter
     #
     def number_with_delimiter(value)
       value.to_s.gsub(/(\d)(?=(\d\d\d)+(?!\d))/, "\\1,")

--- a/lib/git_fame/version.rb
+++ b/lib/git_fame/version.rb
@@ -1,3 +1,3 @@
 module GitFame
-  VERSION = "1.2.1"
+  VERSION = "1.2.2"
 end

--- a/spec/git_fame_spec.rb
+++ b/spec/git_fame_spec.rb
@@ -91,6 +91,26 @@ describe GitFame::Base do
     end
   end
 
+  describe "#command_line_arguments #include" do
+    let(:subject) { GitFame::Base.new({repository: @repository, include: "spec"}) }
+    it "should include the spec folder" do
+      subject.file_list.include?("spec/gash_spec.rb").should be_true
+      subject.file_list.include?("lib/gash.rb").should be_false
+    end
+  end
+
+  describe "#command_line_arguments #include, #since, #until" do
+    let(:subject) { GitFame::Base.new({repository: @repository, since: "2011-01", until: "2012-02"}) }
+    let(:author) { subject.authors.first }
+    it "should include only from time period" do
+      subject.added.should eq(571)
+      subject.deleted.should eq(54)
+      subject.files.should eq(16)
+      subject.commits.should eq(30)
+      subject.loc.should eq(1084)
+    end
+  end
+
   describe "#pretty_print" do
     it "should print" do
       lambda {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,11 @@ require "rspec"
 require "git_fame"
 
 RSpec.configure do |config|
-  config.mock_with :rspec
+  config.mock_with :rspec do |c|
+    c.syntax = [:should, :expect]
+  end
   config.order = "random"
-  config.before(:all) do 
+  config.before(:all) do
     @repository = File.join(File.dirname(File.dirname(__FILE__)), "spec/fixtures/gash")
     Dir.chdir(@repository) do
       `git checkout 7ab01bc5a720`


### PR DESCRIPTION
Features described in README.md

Possible user cases:
1. git fame --include=tests
Show statistics only from tests folder
2. git fame --since=3.months
Show statistics for last 3 months. Support git-time conventions
2. git fame --until=2014-01-01
Show statistics until 2014. Support git-time conventions
