### PR TITLE
Support Ruby 2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
+gem 'rake'
 # Specify your gem's dependencies in git_fame.gemspec
 gemspec

--- a/lib/git_fame/base.rb
+++ b/lib/git_fame/base.rb
@@ -91,13 +91,17 @@ module GitFame
     #
     def authors
       authors = populate.instance_variable_get("@authors").values
-      @sort ? authors.sort_by do |author|
-        if @sort == "name"
-          author.send(@sort)
-        else
-          -1 * author.send("raw_#{@sort}")
+      if @sort
+        authors.sort_by do |author|
+          if @sort == "name"
+            author.send(@sort)
+          else
+            -1 * author.send("raw_#{@sort}")
+          end
         end
-      end : authors
+      else
+        authors
+      end
     end
 
     #f


### PR DESCRIPTION
I was getting the following syntax error when using the latest master version:

```
/usr/local/var/rbenv/versions/2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:69:in `require': /usr/local/var/rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/git_fame-1.2.2/lib/git_fame/base.rb:94: syntax error, unexpected keyword_do_cond, expecting ':' (SyntaxError)
      @sort ? authors.sort_by do |author|
                                ^
```

This PR fixes the syntax error by expanding the ternary if statement.