### PR TITLE
Add option to only consider files with certain extensions

### DIFF
--- a/bin/git-fame
+++ b/bin/git-fame
@@ -13,6 +13,7 @@ opts = Trollop::options do
   opt :bytype, "Group line counts by file extension (i.e. .rb, .erb, .yml)", default: false
   opt :include, "Paths to include in git ls-files", default: "", type: String
   opt :exclude, "Paths to exclude (comma separated)", default: "", type: String
+  opt :extension, "Comma-separated list of extensions to consider, leave blank for all", default: "", type: String
   opt :branch, "Branch to run on", default: "master", type: String
   opt :format, "Format (pretty/csv)", default: "pretty", type: String
 end
@@ -27,6 +28,7 @@ fame = GitFame::Base.new({
   bytype: opts[:bytype],
   include: opts[:include],
   exclude: opts[:exclude],
+  extensions: opts[:extension],
   branch: opts[:branch]
 })
 opts[:format] == "csv" ? fame.csv_puts : fame.pretty_puts

--- a/lib/git_fame/base.rb
+++ b/lib/git_fame/base.rb
@@ -276,7 +276,7 @@ module GitFame
     def remove_excluded_files
       return if @exclude.empty?
       @files = @files.map do |path|
-        next if  path =~ /\A(#{@exclude.join("|")})/
+        next if path =~ /\A(#{@exclude.join("|")})/
         path
       end.compact
     end

--- a/lib/git_fame/base.rb
+++ b/lib/git_fame/base.rb
@@ -19,6 +19,7 @@ module GitFame
       @progressbar  = false
       @whitespace   = false
       @bytype       = false
+      @extensions   = ""
       @exclude      = ""
       @include      = ""
       @authors      = {}
@@ -27,6 +28,7 @@ module GitFame
         instance_variable_set "@" + name.to_s, args[name]
       end
       @exclude = convert_exclude_paths_to_array
+      @extensions = convert_extensions_to_array
       @branch = (@branch.nil? or @branch.empty?) ? "master" : @branch
     end
 
@@ -185,8 +187,9 @@ module GitFame
           raise BranchNotFound.new("Does '#{@branch}' exist?")
         end
 
-        @files = execute("git ls-tree -r #{@branch} --name-only #{@include}").
-          split("\n")
+        command = "git ls-tree -r #{@branch} --name-only #{@include}"
+        command += " | grep \"\\.\\(#{@extensions.join("\\|")}\\)$\"" unless @extensions.empty?
+        @files = execute(command).split("\n")
         @file_extensions = []
         remove_excluded_files
         progressbar = SilentProgressbar.new(
@@ -258,6 +261,13 @@ module GitFame
     #
     def convert_exclude_paths_to_array
       @exclude.split(",").map{|path| path.strip.sub(/\A\//, "") }
+    end
+
+    #
+    # Converts @extensions argument to an array
+    #
+    def convert_extensions_to_array
+      @extensions.split(",")
     end
 
     #

--- a/spec/git_fame_spec.rb
+++ b/spec/git_fame_spec.rb
@@ -92,7 +92,8 @@ describe GitFame::Base do
       GitFame::Base.new({
         repository: @repository, 
         exclude: "lib", 
-        bytype: true
+        bytype: true,
+        extensions: "rb,rdoc"
       }) 
     end
 
@@ -100,7 +101,11 @@ describe GitFame::Base do
       subject.file_list.include?("lib/gash.rb").should be_false
     end
 
-    let(:author) { subject.authors.first }
+    it "should exclude non rb or rdoc files" do
+      subject.file_list.include?("HISTORY").should be_false
+    end
+
+    let(:author) { subject.authors.find { |author| author.name == "7rans" } }
     it "should break out counts by file type" do
       author.file_type_counts["rdoc"].should eq(23)
     end

--- a/spec/git_fame_spec.rb
+++ b/spec/git_fame_spec.rb
@@ -28,10 +28,10 @@ describe GitFame::Base do
       end
     end
     describe "format" do
-      let(:author) do 
+      let(:author) do
         GitFame::Author.new({
-          raw_commits: 12345, 
-          raw_files: 6789, 
+          raw_commits: 12345,
+          raw_files: 6789,
           raw_loc: 1234
         })
       end
@@ -61,7 +61,7 @@ describe GitFame::Base do
   describe "sort" do
     it "should be able to sort #authors by name" do
       authors = GitFame::Base.new({
-        repository: @repository, 
+        repository: @repository,
         sort: "name"
       }).authors
       authors.map(&:name).
@@ -70,7 +70,7 @@ describe GitFame::Base do
 
     it "should be able to sort #authors by commits" do
       authors = GitFame::Base.new({
-        repository: @repository, 
+        repository: @repository,
         sort: "commits"
       }).authors
       authors.map(&:name).
@@ -79,7 +79,7 @@ describe GitFame::Base do
 
     it "should be able to sort #authors by files" do
       authors = GitFame::Base.new({
-        repository: @repository, 
+        repository: @repository,
         sort: "files"
       }).authors
       authors.map(&:name).
@@ -88,13 +88,13 @@ describe GitFame::Base do
   end
 
   describe "#command_line_arguments" do
-    let(:subject) do 
+    let(:subject) do
       GitFame::Base.new({
-        repository: @repository, 
-        exclude: "lib", 
+        repository: @repository,
+        exclude: "lib",
         bytype: true,
         extensions: "rb,rdoc"
-      }) 
+      })
     end
 
     it "should exclude the lib folder" do
@@ -161,7 +161,7 @@ describe GitFame::Base do
   describe "branches" do
     it "should handle existing branches" do
       authors = GitFame::Base.new({
-        repository: @repository, 
+        repository: @repository,
         branch: "0.1.0"
       }).authors
 
@@ -172,7 +172,7 @@ describe GitFame::Base do
     it "should raise an error if branch doesn't exist" do
       expect {
         GitFame::Base.new({
-          repository: @repository, 
+          repository: @repository,
           branch: "f67c2bcbfcfa30fccb36f72dca22a817"
         }).authors
       }.to raise_error(GitFame::BranchNotFound)


### PR DESCRIPTION
This adds an `--extension` parameter, to allow a whitelist of file extensions to consider.