### PR TITLE
Paths containing spaces caused an error

### DIFF
--- a/lib/git_fame/base.rb
+++ b/lib/git_fame/base.rb
@@ -368,6 +368,13 @@ module GitFame
       @authors[(email || "").strip] ||= Author.new({ parent: self, name: name })
     end
 
+    # Lists the paths to contained git submodules
+    def submodules
+      execute("git config --file .gitmodules --get-regexp path | awk '{ print $2 }'") do |result|
+        result.to_s.split(/\n/)
+      end
+    end
+
     # List all files in current git directory, excluding
     # extensions in @extensions defined by the user
     def current_files
@@ -377,7 +384,7 @@ module GitFame
         end
       else
         execute("git #{git_directory_params} ls-tree -r #{commit_range.to_s} --name-only") do |result|
-          filter_files(result.to_s.split(/\n/))
+          filter_files(result.to_s.split(/\n/).select { |f| submodules.index(f) == nil })
         end
       end
     end

--- a/lib/git_fame/base.rb
+++ b/lib/git_fame/base.rb
@@ -376,13 +376,8 @@ module GitFame
           filter_files(result.to_s.split(/\n/))
         end
       else
-        execute("git #{git_directory_params} ls-tree -r #{commit_range.to_s}") do |result|
-          lines = result.to_s.split(/\n/).inject([]) do |lines, line|
-            # Ignore submodules
-            next lines if line.strip.match(/^160000/)
-            next [line.split(/\s+/).last] + lines
-          end
-          filter_files(lines)
+        execute("git #{git_directory_params} ls-tree -r #{commit_range.to_s} --name-only") do |result|
+          filter_files(result.to_s.split(/\n/))
         end
       end
     end


### PR DESCRIPTION
The command for retrieving paths returned more data than the paths and this was split up using a regex, which did not handle spaces in the paths.