### PR TITLE
Escapes filenames used in git commands to fix filenames with a single quote in the name

### DIFF
--- a/lib/git_fame/file.rb
+++ b/lib/git_fame/file.rb
@@ -7,7 +7,7 @@ module GitFame
     end
 
     def to_s
-      path
+      path.gsub(/'/, "'\"'\"'")
     end
   end
 end


### PR DESCRIPTION
Fixes issue #85 

The problem lies in the single quotes used to wrap filenames in `git` commands. Escaping single quotes in bash is dirty, but it does fix the problem (see https://stackoverflow.com/questions/1250079/how-to-escape-single-quotes-within-single-quoted-strings)

I wasn't sure how to update your fixture repo (gash) to add a file with a single quote in the name. However, functional testing on bash fixes the issue. In a local repo, I added a commit with the file m'lady.txt and ran git fame (from master).

```
$ git fame
Error: Could not run 'git --git-dir='/arches/attribute_stats/.git' --work-tree='/arches/attribute_stats' show master:'m'lady.txt' | LC_ALL=C file --mime-type -' => sh: -c: line 0: unexpected EOF while looking for matching `''

``` 

After this patch, it works as expected.