### PR TITLE
Fix various grammar and spelling issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Active files: 21
 Active lines: 967
 Total commits: 109
 
-Note: Files matching MIME type image, binary has been ignored
+Note: Files matching MIME type image, binary have been ignored
 
 +----------------+-----+---------+-------+---------------------+
 | name           | loc | commits | files | distribution (%)    |
@@ -104,11 +104,11 @@ repository = GitFame::Base.new(options)
 
 `author = repository.authors.first`
 
-- Formated
+- Formatted
   - `author.loc` (String) Number of lines.
   - `author.commits` (String) Number of commits.
   - `author.files` (String) Number of files changed.
-- Non formated
+- Non formatted
   - `author.distribution` (String) Distribution (in %) between users (loc/commits/files)
   - `author.raw_loc` (Fixnum) Number of lines.
   - `author.raw_commits` (Fixnum) Number of commits.

--- a/bin/git-fame
+++ b/bin/git-fame
@@ -17,7 +17,7 @@ opts = Trollop::options do
   opt :extension, "Comma-separated list of extensions to consider, leave blank for all", default: "", type: String
   opt :branch, "Branch to run on", default: "HEAD", type: String
   opt :format, "Format (pretty/csv)", default: "pretty", type: String
-  opt :after, "Only use commmits after this date. Format: yyyy-mm-dd. Note that the given date is included", type: String
+  opt :after, "Only use commits after this date. Format: yyyy-mm-dd. Note that the given date is included", type: String
   opt :before, "Only use commits before this date. Format: yyyy-mm-dd. Note that the given date is included", type: String
   opt :verbose, "Print shell commands used by git-fame", default: false
   opt :timeout, "Set timeout in seconds for each git command. Turn off by using -1", type: Integer, default: GitFame::CMD_TIMEOUT

--- a/lib/git_fame/base.rb
+++ b/lib/git_fame/base.rb
@@ -103,7 +103,7 @@ module GitFame
       puts "Active lines: #{number_with_delimiter(loc)}"
       puts "Total commits: #{number_with_delimiter(commits)}\n"
       unless @everything
-        puts "\nNote: Files matching MIME type #{ignore_types.join(", ")} has been ignored\n\n"
+        puts "\nNote: Files matching MIME type #{ignore_types.join(", ")} have been ignored\n\n"
       end
       table(authors, fields: printable_fields)
     end
@@ -184,7 +184,7 @@ module GitFame
 
         # -w ignore whitespaces (defined in @wopt)
         # -M detect moved or copied lines.
-        # -p procelain mode (parsed by BlameParser)
+        # -p porcelain mode (parsed by BlameParser)
         execute("git #{git_directory_params} blame #{encoding_opt} -p -M #{default_params} #{commit_range.to_s} #{@wopt} -- '#{file}'") do |result|
           BlameParser.new(result.to_s).parse.each do |row|
             next if row[:boundary]
@@ -309,7 +309,7 @@ module GitFame
     end
 
     # Command to be executed at @repository
-    # @silent = true wont raise an error on exit code =! 0
+    # @silent = true won't raise an error on exit code =! 0
     def execute(command, silent = false, &block)
       result = run_with_timeout(command)
       if result.success? or silent
@@ -349,7 +349,7 @@ module GitFame
       end
     end
 
-    # In those cases the users havent defined a branch
+    # In those cases the users haven't defined a branch
     # We try to define it for him/her by
     # 1. check if { @default_settings.fetch(:branch) } exists
     # 1. look at .git/HEAD (basically)
@@ -423,7 +423,7 @@ module GitFame
         end
 
         if end_date > end_commit_date and start_date > end_commit_date
-          raise Error, "after=#{@after} and before=#{@before} is set too high, higest is #{end_commit_date}"
+          raise Error, "after=#{@after} and before=#{@before} is set too high, highest is #{end_commit_date}"
         end
 
         if end_date < start_commit_date and start_date < start_commit_date
@@ -461,7 +461,7 @@ module GitFame
         commit1 = execute("git #{git_directory_params} rev-list --before='#{end_of_yesterday(@after)}' #{default_params} '#{@branch}' | head -1").to_s
 
         # No commit found this early
-        # If NO end date is choosen, just use current branch
+        # If NO end date is chosen, just use current branch
         # Otherwise use specified (@before) as end date
         if blank?(commit1)
           return @branch unless @before

--- a/lib/git_fame/blame_parser.rb
+++ b/lib/git_fame/blame_parser.rb
@@ -21,7 +21,7 @@ module GitFame
       end
       chunks
     rescue Exception => error
-      raise Error, "Failed parsing Procelain: #{error.message}"
+      raise Error, "Failed parsing Porcelain: #{error.message}"
     end
 
     def is_header?(line)

--- a/lib/git_fame/helper.rb
+++ b/lib/git_fame/helper.rb
@@ -1,8 +1,8 @@
 module GitFame
   module Helper
     #
-    # @value Fixnum Value to be formated
-    # @return String Formated according ActionView::Helpers::NumberHelper.number_with_delimiter
+    # @value Fixnum Value to be formatted
+    # @return String Formatted according ActionView::Helpers::NumberHelper.number_with_delimiter
     #
     def number_with_delimiter(value)
       value.to_s.gsub(/(\d)(?=(\d\d\d)+(?!\d))/, "\\1,")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,7 +53,7 @@ RSpec.configure do |config|
     warn "\t#{`grep --version`.strip}"
     warn "Spec notes:".yellow
     if suppress_stdout
-      warn "\tMessages to STDOUT has been suppressed. See spec/spec_helper.rb".red
+      warn "\tWriting to STDOUT has been suppressed. See spec/spec_helper.rb".red
     end
     warn "\tRequires git 2.x for specs to pass"
     warn "\tTime zone during testing is set to #{ENV["TZ"]}"


### PR DESCRIPTION
While using this tool, I noticed a grammatical number mismatch in the sentence

> Note: Files matching MIME type image, binary has been ignored

(Since the subject is "Files", the verb should be "have been" to match.)

This PR fixes that sentence both in the code and in the README, and adjusts another sentence that had a similar issue with "has been".

While I was at it, I also fixed a bunch of other typos across the codebase, found using [codespell](https://github.com/codespell-project/codespell). Note that this includes the fix done in #79.