### PR TITLE
Add missing require

### DIFF
--- a/lib/git_fame/command.rb
+++ b/lib/git_fame/command.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/enumerable"
+require "active_support/core_ext/object/blank"
 require "tty-option"
 require "tty-spinner"
 


### PR DESCRIPTION
To make `compact_blank` work we need both:
- `compact_blank` itself
- `Object#blank` This commit adds a require for the latter.

Fixes #133.